### PR TITLE
fix indigo theme package name color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # DocThemeIndigo
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://Roger-luo.github.io/DocThemeIndigo.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://Roger-luo.github.io/DocThemeIndigo.jl/dev)
 [![Build Status](https://github.com/Roger-luo/DocThemeIndigo.jl/workflows/CI/badge.svg)](https://github.com/Roger-luo/DocThemeIndigo.jl/actions)
 [![Coverage](https://codecov.io/gh/Roger-luo/DocThemeIndigo.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/Roger-luo/DocThemeIndigo.jl)
 

--- a/assets/indigo.scss
+++ b/assets/indigo.scss
@@ -30,6 +30,12 @@
       box-shadow: none;
       color: #FFFFFF;
       background-color: #194E82;
+
+      .docs-package-name {
+        a, a:hover {
+          color: #FFFFFF;
+        }
+      }
   
       ul.docs-menu {
         border-top: none;

--- a/src/DocThemeIndigo.jl
+++ b/src/DocThemeIndigo.jl
@@ -3,27 +3,14 @@ module DocThemeIndigo
 using Sass
 
 function install(m::Module)
-    pkg = dirname(dirname(pathof(m)))
+    pkg = pkgdir(m)
     doc = joinpath(pkg, "docs")
     src = joinpath(@__DIR__, "..", "assets", "indigo.scss")
     assets = joinpath(doc, "src", "assets")
     dst = joinpath(assets, "indigo.css")
     ispath(assets) || mkpath(assets)
     Sass.compile_file(src, dst)
-    gitignore = joinpath(pkg, ".gitignore")
-
-    if !is_indigo_css_ignore(m)
-        open(gitignore, "a+") do f
-            println(f, "/docs/src/assets/indigo.css")
-        end
-    end
     return joinpath("assets", "indigo.css")
-end
-
-function is_indigo_css_ignore(m::Module)
-    pkg = dirname(dirname(pathof(m)))
-    gitignore = joinpath(pkg, ".gitignore")
-    return isfile(gitignore) && ("/docs/src/assets/indigo.css" in readlines(gitignore))
 end
 
 end

--- a/src/DocThemeIndigo.jl
+++ b/src/DocThemeIndigo.jl
@@ -3,13 +3,27 @@ module DocThemeIndigo
 using Sass
 
 function install(m::Module)
-    doc = joinpath(dirname(dirname(pathof(m))), "docs")
+    pkg = dirname(dirname(pathof(m)))
+    doc = joinpath(pkg, "docs")
     src = joinpath(@__DIR__, "..", "assets", "indigo.scss")
     assets = joinpath(doc, "src", "assets")
     dst = joinpath(assets, "indigo.css")
     ispath(assets) || mkpath(assets)
     Sass.compile_file(src, dst)
+    gitignore = joinpath(pkg, ".gitignore")
+
+    if !is_indigo_css_ignore(m)
+        open(gitignore, "a+") do f
+            println(f, "/docs/src/assets/indigo.css")
+        end
+    end
     return joinpath("assets", "indigo.css")
+end
+
+function is_indigo_css_ignore(m::Module)
+    pkg = dirname(dirname(pathof(m)))
+    gitignore = joinpath(pkg, ".gitignore")
+    return isfile(gitignore) && ("/docs/src/assets/indigo.css" in readlines(gitignore))
 end
 
 end


### PR DESCRIPTION
the new Documenter version specified the package-name color, this PR set it back to white

before

![image](https://user-images.githubusercontent.com/8445510/124696761-a4c7c580-deb3-11eb-8199-2405b23ac920.png)


after
![image](https://user-images.githubusercontent.com/8445510/124696742-9e394e00-deb3-11eb-808b-c642b9930ef7.png)
